### PR TITLE
remove the dublicate entry of testsuit_SOURCES

### DIFF
--- a/testsuit/Makefile.am
+++ b/testsuit/Makefile.am
@@ -1,6 +1,5 @@
 bin_PROGRAMS = testsuit
 check_PROGRAMS = testsuit
-testsuit_SOURCES = testsuit.c
 
 AUTOMAKE_OPTIONS = subdir-objects
 


### PR DESCRIPTION
## Description
remove the  automake warning for the testsuit

Fixes # (issue)

---

## Type of change
<!-- Check the relevant options with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

---

## How has this been tested?
try run of  automake

- [X] Local build successful
- [X] Unit tests passed
- [ ] Other (please describe):

---

## Checklist
<!-- Put an "x" in the boxes that apply. -->

- [X] I have performed a self-review of my code
- [X] I have added comments in the code where necessary
- [X] I have added/updated documentation if needed
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] All tests passed locally

---

## Additional notes
<!-- Add any additional context, screenshots, or info here. -->
