### PR TITLE
Potential fix for code scanning alert no. 3: Potential use after free

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -1133,6 +1133,7 @@ void chanmode(MsgItem_t *pMsg) {
     	                } else if (sNewMode.pModeStr[i]=='l' && sNewMode.pLimit) {
         	                if (sChannelData.sModes.pLimit) {
                                 free(sChannelData.sModes.pLimit);
+                                sChannelData.sModes.pLimit = NULL;
                             }
     
             	            sChannelData.sModes.pLimit=(char*)malloc((strlen(sNewMode.pLimit)+1)*sizeof(char));
@@ -1157,9 +1158,8 @@ void chanmode(MsgItem_t *pMsg) {
     	                } else if (sChannelData.sModes.pModeStr[i]=='l') {
         	                if (sChannelData.sModes.pLimit) {
                                 free(sChannelData.sModes.pLimit);
+                                sChannelData.sModes.pLimit = NULL;
                             }
-                            
-                            sChannelData.sModes.pLimit=NULL;
             	        }
                 	}
     


### PR DESCRIPTION
Potential fix for [https://github.com/McWuragu/ebotula/security/code-scanning/3](https://github.com/McWuragu/ebotula/security/code-scanning/3)

The best way to fix the use-after-free problem is to ensure that after a call to `free`, a pointer is always set to `NULL` before any future use. Specifically, after freeing (e.g., `free(sChannelData.sModes.pLimit);`), assign `sChannelData.sModes.pLimit = NULL;`. This ensures that subsequent logic that checks or uses this pointer (for example, with `if (sChannelData.sModes.pLimit)`) will work safely—`NULL` is never dereferenced nor freed. 

For this code, insert `sChannelData.sModes.pLimit = NULL;` immediately after every `free(sChannelData.sModes.pLimit);` call (notably on line 1135 and on 1160), and ensure that prior to assigning a new allocation to it, it is in a safe state. This also helps make subsequent checks like `if (sChannelData.sModes.pLimit)` accurate. This change is minimal, targeted, and does not affect other parts of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
