### PR TITLE
Fix potential use-after-free in chanmode handling for +k/+l modes

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -1143,46 +1143,53 @@ void chanmode(MsgItem_t *pMsg) {
                     	/* set the new flag */
     	                sChannelData.sModes.pModeStr[i]=sNewMode.pModeStr[i];
     	
-        	            /* set keyword and limit */
-            	        if (sNewMode.pModeStr[i]=='k' && sNewMode.pKeyword) {
-                	        if (sChannelData.sModes.pKeyword){
+	            /* set keyword and limit */
+	            if (sNewMode.pModeStr[i]=='k' && sNewMode.pKeyword) {
+                        char *pNewKeyword;
+
+	                pNewKeyword=(char*)malloc((strlen(sNewMode.pKeyword)+1)*sizeof(char));
+	                if (pNewKeyword) {
+                            strcpy(pNewKeyword,sNewMode.pKeyword);
+                            if (sChannelData.sModes.pKeyword) {
                                 free(sChannelData.sModes.pKeyword);
                             }
-    
-                    	    sChannelData.sModes.pKeyword=(char*)malloc((strlen(sNewMode.pKeyword)+1)*sizeof(char));
-                        	strcpy(sChannelData.sModes.pKeyword,sNewMode.pKeyword);
-    	                } else if (sNewMode.pModeStr[i]=='l' && sNewMode.pLimit) {
-        	                if (sChannelData.sModes.pLimit) {
+                            sChannelData.sModes.pKeyword=pNewKeyword;
+                        }
+	                } else if (sNewMode.pModeStr[i]=='l' && sNewMode.pLimit) {
+                        char *pNewLimit;
+
+	                pNewLimit=(char*)malloc((strlen(sNewMode.pLimit)+1)*sizeof(char));
+	                if (pNewLimit) {
+                            strcpy(pNewLimit,sNewMode.pLimit);
+	        	            if (sChannelData.sModes.pLimit) {
                                 free(sChannelData.sModes.pLimit);
-                                sChannelData.sModes.pLimit = NULL;
                             }
-    
-            	            sChannelData.sModes.pLimit=(char*)malloc((strlen(sNewMode.pLimit)+1)*sizeof(char));
-                	        strcpy(sChannelData.sModes.pLimit,sNewMode.pLimit);
-                    	}
-    	            }
+                            sChannelData.sModes.pLimit=pNewLimit;
+                        }
+	                    }
+	            }
     
         	    } else if (sNewMode.pModeStr[MOD_TYPE]=='-') {
             	    /* remove  flags from the pChanneldata */
                 	if (sNewMode.pModeStr[i]!=' ') {
     
-    	                /* remove the  mode flag */
-        	            sChannelData.sModes.pModeStr[i]=' ';
-    
-            	        /* remove keyword and limit */
-                	    if (sChannelData.sModes.pModeStr[i]=='k') {
-                    	    if (sChannelData.sModes.pKeyword){
+	            /* remove keyword and limit */
+	            if (sNewMode.pModeStr[i]=='k') {
+	                    if (sChannelData.sModes.pKeyword){
                                 free(sChannelData.sModes.pKeyword);
                             }
-    
+
                             sChannelData.sModes.pKeyword=NULL;
-    	                } else if (sChannelData.sModes.pModeStr[i]=='l') {
-        	                if (sChannelData.sModes.pLimit) {
+	                } else if (sNewMode.pModeStr[i]=='l') {
+	        	            if (sChannelData.sModes.pLimit) {
                                 free(sChannelData.sModes.pLimit);
                                 sChannelData.sModes.pLimit = NULL;
                             }
-            	        }
-                	}
+	            }
+
+	                /* remove the  mode flag */
+	            sChannelData.sModes.pModeStr[i]=' ';
+	                }
     
     	        }
     
@@ -1215,6 +1222,8 @@ void chanmode(MsgItem_t *pMsg) {
             free(sChannelData.pGreeting);
             free(sChannelData.sModes.pKeyword);
             free(sChannelData.sModes.pLimit);
+            free(sNewMode.pKeyword);
+            free(sNewMode.pLimit);
         } else {
             sendMsg(pMsg->AnswerMode,pMsg->pCallingNick,_("The channel %s isn't in the channel list."),pMsg->pAccessChannel);
         }
@@ -1519,5 +1528,4 @@ void inviteuser(MsgItem_t *pMsg){
     
     free(pInviteNick);
 }
-
 


### PR DESCRIPTION
### Motivation
- CodeQL flagged a potential use-after-free when updating channel `+k`/`+l` parameters because existing buffers could be freed before a new value was safely allocated and copied.

### Description
- In `src/command.c` `chanmode` logic now allocates temporary buffers (`pNewKeyword`, `pNewLimit`) and copies `sNewMode` data into them before freeing and replacing `sChannelData.sModes` pointers, avoiding dangling-pointer windows when updating `+k`/`+l`.
- The removal (`-`) branch now checks the requested flag in `sNewMode.pModeStr[i]` before freeing and nulling the corresponding `sChannelData` pointers, and then clears the mode flag at the end of the branch.
- The temporary allocations inside `sNewMode` (`pKeyword`, `pLimit`) are freed at the end of `chanmode` to prevent leaks.

### Testing
- Ran `make -j2`, which failed in this environment because there is no top-level `Makefile` present (not a failure of the change itself).
- Ran `gcc -Isrc/include -fsyntax-only src/command.c`, which could not complete because `config.h` is not available in this environment (configure step is required), so no full compile was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a301efe878832e929722f0380ca3fc)