### PR TITLE
Add ConfigParser unit tests and integrate into testsuit

### DIFF
--- a/testsuit/Makefile.am
+++ b/testsuit/Makefile.am
@@ -11,10 +11,12 @@ testsuit_SOURCES = \
 	queue_test.c \
 	extract_test.c \
 	callbacklist_test.c \
+	configparser_test.c \
 	../src/utilities.c \
 	../src/queue.c \
 	../src/extract.c \
-	../src/callbacklist.c
+	../src/callbacklist.c \
+	../src/configparser.c
 	 
 
 noinst_HEADERS =  \
@@ -23,11 +25,13 @@ noinst_HEADERS =  \
 	include/queue_test.h \
 	include/extract_test.h \
 	include/callbacklist_test.h \
+	include/configparser_test.h \
 	../src/include/utilities.h \
 	../src/include/queue.h \
 	../src/include/extract.h \
 	../src/include/callbacklist.h \
-	../src/include/callback.h
+	../src/include/callback.h \
+	../src/include/configparser.h
 	
 
 testsuit_LDADD = $(GDBM_LIB) $(CRYPT_LIB) $(PTHREAD_LIB) $(RT_LIB) $(CUNIT_LIB)

--- a/testsuit/configparser_test.c
+++ b/testsuit/configparser_test.c
@@ -1,0 +1,154 @@
+/* #############################################################
+ *
+ *  This file is a part of ebotula testsuit.
+ *
+ *  Coypright (C)2023-2024 Steffen Laube <Laube.Steffen@gmx.de>
+ *
+ * #############################################################
+ */
+
+#include "configparser_test.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "type.h"
+
+extern ConfigSetup_t sSetup;
+extern InputValueStruct_t vsInputConfig[VAL_COUNT];
+
+extern int key_int_checker(const void * value,const void* range1,const void *range2,const char *param_name);
+extern int key_server_checker(const void * value,const void* range1,const void *range2,const char *param_name);
+extern int key_nick_checker(const void * value,const void* range1,const void *range2,const char *param_name);
+
+static void reset_parser_state(void) {
+    int i;
+
+    for (i = 0; i < VAL_COUNT; i++) {
+        vsInputConfig[i].isFound = false;
+    }
+
+    free(sSetup.pBotname);
+    free(sSetup.realname);
+    free(sSetup.sHostname);
+    free(sSetup.sPort);
+    free(sSetup.configfile);
+    free(sSetup.pDatabasePath);
+    free(sSetup.sExeUser);
+    free(sSetup.sExeGroup);
+    free(sSetup.sNickServIdent);
+
+    memset(&sSetup, 0, sizeof(sSetup));
+}
+
+static char *write_temp_config(const char *content) {
+    static const char tmpl[] = "/tmp/ebotula-configparser-XXXXXX";
+    char *path = strdup(tmpl);
+    int fd;
+
+    if (!path) {
+        return NULL;
+    }
+
+    fd = mkstemp(path);
+    if (fd < 0) {
+        free(path);
+        return NULL;
+    }
+
+    if (write(fd, content, strlen(content)) < 0) {
+        close(fd);
+        unlink(path);
+        free(path);
+        return NULL;
+    }
+
+    close(fd);
+    return path;
+}
+
+int init_configparser(void) {
+    reset_parser_state();
+    return 0;
+}
+
+int clean_configparser(void) {
+    reset_parser_state();
+    return 0;
+}
+
+void test_key_int_checker_valid_boundary(void) {
+    errno = 0;
+    CU_ASSERT_EQUAL(key_int_checker("1", (void*)1, (void*)10, "threadlimit"), 0);
+    CU_ASSERT_EQUAL(errno, 0);
+}
+
+void test_key_int_checker_below_min(void) {
+    errno = 0;
+    CU_ASSERT_EQUAL(key_int_checker("0", (void*)1, (void*)10, "threadlimit"), EDOM);
+    CU_ASSERT_EQUAL(errno, EDOM);
+}
+
+void test_key_server_checker_invalid(void) {
+    errno = 0;
+    CU_ASSERT_EQUAL(key_server_checker("bad host", NULL, NULL, "hostname"), EINVAL);
+    CU_ASSERT_EQUAL(errno, EINVAL);
+}
+
+void test_key_nick_checker_valid(void) {
+    errno = 0;
+    CU_ASSERT_EQUAL(key_nick_checker("MyBot_1", NULL, NULL, "botname"), 0);
+    CU_ASSERT_EQUAL(errno, 0);
+}
+
+void test_key_nick_checker_invalid(void) {
+    errno = 0;
+    CU_ASSERT_EQUAL(key_nick_checker("My Bot", NULL, NULL, "botname"), EINVAL);
+    CU_ASSERT_EQUAL(errno, EINVAL);
+}
+
+void test_ConfigFileParser_valid_config(void) {
+    char *path = write_temp_config(
+        "# comment line\n"
+        "botname = UnitBot\n"
+        "hostname=irc.example.org\n"
+        "port=6667\n"
+        "threadlimit=4\n"
+        "databasepath=/tmp/ebotula-db\n"
+        "loglevel=4\n");
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(path);
+
+    sSetup.configfile = strdup(path);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(sSetup.configfile);
+
+    CU_ASSERT_EQUAL(ConfigFileParser(), 0);
+    CU_ASSERT_STRING_EQUAL(sSetup.pBotname, "UnitBot");
+    CU_ASSERT_STRING_EQUAL(sSetup.sHostname, "irc.example.org");
+    CU_ASSERT_STRING_EQUAL(sSetup.sPort, "6667");
+    CU_ASSERT_EQUAL(sSetup.thread_limit, 4);
+    CU_ASSERT_STRING_EQUAL(sSetup.pDatabasePath, "/tmp/ebotula-db");
+    CU_ASSERT_EQUAL(sSetup.nLogLevel, 4);
+
+    unlink(path);
+    free(path);
+}
+
+void test_ConfigFileParser_duplicate_key_uses_first_value(void) {
+    char *path = write_temp_config(
+        "botname=FirstBot\n"
+        "botname=SecondBot\n");
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(path);
+
+    sSetup.configfile = strdup(path);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(sSetup.configfile);
+
+    CU_ASSERT_EQUAL(ConfigFileParser(), 0);
+    CU_ASSERT_STRING_EQUAL(sSetup.pBotname, "FirstBot");
+
+    unlink(path);
+    free(path);
+}

--- a/testsuit/include/configparser_test.h
+++ b/testsuit/include/configparser_test.h
@@ -1,0 +1,41 @@
+/* #############################################################
+ *
+ *  This file is a part of ebotula testsuit.
+ *
+ *  Coypright (C)2023-2024 Steffen Laube <Laube.Steffen@gmx.de>
+ *
+ * #############################################################
+ */
+
+#include "testsuit.h"
+#include "configparser.h"
+#include <CUnit/CUnit.h>
+#include <CUnit/Basic.h>
+
+#ifndef TESTSUIT_INCLUDE_CONFIGPARSER_TEST_H_
+#define TESTSUIT_INCLUDE_CONFIGPARSER_TEST_H_
+
+int init_configparser(void);
+int clean_configparser(void);
+
+void test_key_int_checker_valid_boundary(void);
+void test_key_int_checker_below_min(void);
+void test_key_server_checker_invalid(void);
+void test_key_nick_checker_valid(void);
+void test_key_nick_checker_invalid(void);
+void test_ConfigFileParser_valid_config(void);
+void test_ConfigFileParser_duplicate_key_uses_first_value(void);
+
+#define NUMBER_OF_CONFIGPARSER_TESTS 7
+
+static strTestDesc_t pstrConfigParserTestSet[NUMBER_OF_CONFIGPARSER_TESTS] = {
+    {test_key_int_checker_valid_boundary,                "key_int_checker(): accept value on min boundary"},
+    {test_key_int_checker_below_min,                     "key_int_checker(): reject value below min"},
+    {test_key_server_checker_invalid,                    "key_server_checker(): reject invalid hostname"},
+    {test_key_nick_checker_valid,                        "key_nick_checker(): accept valid botname"},
+    {test_key_nick_checker_invalid,                      "key_nick_checker(): reject invalid botname"},
+    {test_ConfigFileParser_valid_config,                 "ConfigFileParser(): parse valid configuration"},
+    {test_ConfigFileParser_duplicate_key_uses_first_value, "ConfigFileParser(): duplicate key keeps first value"}
+};
+
+#endif /* TESTSUIT_INCLUDE_CONFIGPARSER_TEST_H_ */

--- a/testsuit/testsuit.c
+++ b/testsuit/testsuit.c
@@ -26,6 +26,7 @@
 #include "queue_test.h"
 #include "extract_test.h"
 #include "callbacklist_test.h"
+#include "configparser_test.h"
 
 
 int main () {
@@ -91,6 +92,20 @@ int main () {
 
 	for (nIndex=0; nIndex<NUMBER_OF_CALLBACKLIST_TESTS; nIndex++ ) {
 		if (NULL == CU_add_test(pSuite, pstrCallbackListTestSet[nIndex].pDesc, pstrCallbackListTestSet[nIndex].TestFkt)){
+			CU_cleanup_registry();
+			return CU_get_error();
+		}
+	}
+
+	/* add a suite to the registry */
+	pSuite = CU_add_suite("ConfigParser", init_configparser, clean_configparser);
+	if (NULL == pSuite) {
+		CU_cleanup_registry();
+		return CU_get_error();
+	}
+
+	for (nIndex=0; nIndex<NUMBER_OF_CONFIGPARSER_TESTS; nIndex++ ) {
+		if (NULL == CU_add_test(pSuite, pstrConfigParserTestSet[nIndex].pDesc, pstrConfigParserTestSet[nIndex].TestFkt)){
 			CU_cleanup_registry();
 			return CU_get_error();
 		}


### PR DESCRIPTION
### Motivation
- Improve test coverage for the configuration parser and its validation helpers to catch regressions in parsing and key validation behavior.
- Integrate the config parser tests into the existing CUnit-based test harness so they run as part of the standard test suite.

### Description
- Add `testsuit/configparser_test.c` which implements tests for `key_int_checker`, `key_server_checker`, `key_nick_checker`, and `ConfigFileParser` (including valid parsing and duplicate-key behavior).
- Add `testsuit/include/configparser_test.h` exposing the test init/cleanup functions and the `pstrConfigParserTestSet` descriptor array of tests.
- Update `testsuit/Makefile.am` to include the new test source and header and to compile/link `../src/configparser.c` into the test binary.
- Update `testsuit/testsuit.c` to register the new `ConfigParser` suite with `CU_add_suite` and add all tests from `pstrConfigParserTestSet` into the main runner.

### Testing
- Built the tests and executed the CUnit test runner via `make check` which invokes `CU_basic_run_tests()` for the suite. 
- The added config parser tests executed under the CUnit basic runner and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64591386c832e9e145850956e4dcf)