### PR TITLE
Add ParserPipeline CUnit tests for preParser and integrate into testsuit

### DIFF
--- a/testsuit/Makefile.am
+++ b/testsuit/Makefile.am
@@ -12,11 +12,14 @@ testsuit_SOURCES = \
 	extract_test.c \
 	callbacklist_test.c \
 	configparser_test.c \
+	parser_pipeline_test.c \
 	../src/utilities.c \
 	../src/queue.c \
 	../src/extract.c \
 	../src/callbacklist.c \
-	../src/configparser.c
+	../src/configparser.c \
+	../src/parser.c \
+	../src/cmdlist.c
 	 
 
 noinst_HEADERS =  \
@@ -26,15 +29,21 @@ noinst_HEADERS =  \
 	include/extract_test.h \
 	include/callbacklist_test.h \
 	include/configparser_test.h \
+	include/parser_pipeline_test.h \
 	../src/include/utilities.h \
 	../src/include/queue.h \
 	../src/include/extract.h \
 	../src/include/callbacklist.h \
 	../src/include/callback.h \
-	../src/include/configparser.h
+	../src/include/configparser.h \
+	../src/include/parser.h \
+	../src/include/cmdlist.h \
+	../src/include/cmdtypes.h \
+	../src/include/command.h \
+	../src/include/handles.h \
+	../src/include/ctcp.h
 	
 
 testsuit_LDADD = $(GDBM_LIB) $(CRYPT_LIB) $(PTHREAD_LIB) $(RT_LIB) $(CUNIT_LIB)
 testsuit_LDFLAGS =$(DFLAGS) $(PFLAGS)
 testsuit_CFLAGS = $(DFLAGS) $(PFLAGS) -I$(top_srcdir)/testsuit/include -I$(top_srcdir)/src/include
-

--- a/testsuit/include/parser_pipeline_test.h
+++ b/testsuit/include/parser_pipeline_test.h
@@ -1,0 +1,31 @@
+/* #############################################################
+ *
+ *  This file is a part of ebotula testsuit.
+ *
+ * #############################################################
+ */
+
+#ifndef TESTSUIT_INCLUDE_PARSER_PIPELINE_TEST_H_
+#define TESTSUIT_INCLUDE_PARSER_PIPELINE_TEST_H_
+
+#include "testsuit.h"
+#include "parser.h"
+
+int init_parser_pipeline(void);
+int clean_parser_pipeline(void);
+
+void test_preParser_ping_calls_pong_direct(void);
+void test_preParser_identifies_bot_command(void);
+void test_preParser_identifies_ctcp_command(void);
+void test_preParser_unknown_message_no_dispatch(void);
+
+#define NUMBER_OF_PARSER_PIPELINE_TESTS 4
+
+static strTestDesc_t pstrParserPipelineTestSet[NUMBER_OF_PARSER_PIPELINE_TESTS] = {
+    {test_preParser_ping_calls_pong_direct,        "preParser(): handles PING synchronously"},
+    {test_preParser_identifies_bot_command,        "preParser(): identifies !help command"},
+    {test_preParser_identifies_ctcp_command,       "preParser(): identifies CTCP VERSION"},
+    {test_preParser_unknown_message_no_dispatch,   "preParser(): ignores unknown message"}
+};
+
+#endif /* TESTSUIT_INCLUDE_PARSER_PIPELINE_TEST_H_ */

--- a/testsuit/parser_pipeline_test.c
+++ b/testsuit/parser_pipeline_test.c
@@ -7,7 +7,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <stdarg.h>
 #include "parser_pipeline_test.h"
 #include "ircbot.h"
 
@@ -88,11 +87,6 @@ void pong(char *pPong) {
 
 void SendLine(char *pMsg) {(void)pMsg;}
 void notice(char *pNick, char *pMsgStr) {(void)pNick; (void)pMsgStr;}
-int logger(int priority, char *format, ...) {
-    (void)priority;
-    (void)format;
-    return 0;
-}
 UserLevel_t getUserLevel(char *const pChannel, char *const pNetmask) {
     (void)pChannel;
     (void)pNetmask;

--- a/testsuit/parser_pipeline_test.c
+++ b/testsuit/parser_pipeline_test.c
@@ -1,0 +1,143 @@
+/* #############################################################
+ *
+ *  This file is a part of ebotula testsuit.
+ *
+ * #############################################################
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include "parser_pipeline_test.h"
+#include "ircbot.h"
+
+boolean stop = false;
+
+static int gPongCallCount = 0;
+static char gPongArg[256];
+
+int init_parser_pipeline(void) {
+    gPongCallCount = 0;
+    gPongArg[0] = '\0';
+    return 0;
+}
+
+int clean_parser_pipeline(void) {
+    gPongCallCount = 0;
+    gPongArg[0] = '\0';
+    return 0;
+}
+
+void test_preParser_ping_calls_pong_direct(void) {
+    MsgBuf_t msg;
+    char line[] = "PING :irc.example.org";
+
+    preParser(line, &msg);
+
+    CU_ASSERT_EQUAL(msg.identify, CMD_NONE);
+    CU_ASSERT_PTR_NULL(msg.pMsgLine);
+    CU_ASSERT_EQUAL(gPongCallCount, 1);
+    CU_ASSERT_STRING_EQUAL(gPongArg, ":irc.example.org");
+}
+
+void test_preParser_identifies_bot_command(void) {
+    MsgBuf_t msg;
+    char line[] = ":nick!user@host PRIVMSG #chan :!help";
+
+    preParser(line, &msg);
+
+    CU_ASSERT_EQUAL(msg.identify, CMD_HELP);
+    CU_ASSERT_PTR_NOT_NULL(msg.pMsgLine);
+    if (msg.pMsgLine) {
+        CU_ASSERT_STRING_EQUAL(msg.pMsgLine, line);
+        free(msg.pMsgLine);
+    }
+}
+
+void test_preParser_identifies_ctcp_command(void) {
+    MsgBuf_t msg;
+    char line[] = ":nick!user@host PRIVMSG ebotula :\001VERSION\001";
+
+    preParser(line, &msg);
+
+    CU_ASSERT_EQUAL(msg.identify, CMD_CTCPVERSION);
+    CU_ASSERT_PTR_NOT_NULL(msg.pMsgLine);
+    free(msg.pMsgLine);
+}
+
+void test_preParser_unknown_message_no_dispatch(void) {
+    MsgBuf_t msg;
+    char line[] = ":server NOTICE user :plain notice without bot command";
+
+    preParser(line, &msg);
+
+    CU_ASSERT_EQUAL(msg.identify, CMD_NONE);
+    CU_ASSERT_PTR_NULL(msg.pMsgLine);
+}
+
+/* ---------- Test doubles to isolate parser/cmdlist ---------- */
+void pong(char *pPong) {
+    gPongCallCount++;
+    if (pPong == NULL) {
+        gPongArg[0] = '\0';
+        return;
+    }
+    strncpy(gPongArg, pPong, sizeof(gPongArg) - 1);
+    gPongArg[sizeof(gPongArg) - 1] = '\0';
+}
+
+void SendLine(char *pMsg) {(void)pMsg;}
+void notice(char *pNick, char *pMsgStr) {(void)pNick; (void)pMsgStr;}
+int logger(int priority, char *format, ...) {
+    (void)priority;
+    (void)format;
+    return 0;
+}
+UserLevel_t getUserLevel(char *const pChannel, char *const pNetmask) {
+    (void)pChannel;
+    (void)pNetmask;
+    return MasterLevel;
+}
+
+/* Event and command handlers referenced by CmdHandleField */
+void hPong(MsgItem_t *pMsg) {(void)pMsg;}
+void hNickChange(MsgItem_t *pMsg) {(void)pMsg;}
+void hResetModes(MsgItem_t *pMsg) {(void)pMsg;}
+void hRejoinAfterKick(MsgItem_t *pMsg) {(void)pMsg;}
+void hUserJoin(MsgItem_t *pMsg) {(void)pMsg;}
+void hBotNeedOp(MsgItem_t *pMsg) {(void)pMsg;}
+void hResetTopic(MsgItem_t *pMsg) {(void)pMsg;}
+void hCallback(MsgItem_t *pMsg) {(void)pMsg;}
+void hWhoisFailed(MsgItem_t *pMsg) {(void)pMsg;}
+
+void ctcpping(MsgItem_t *pMsg) {(void)pMsg;}
+void ctcpversion(MsgItem_t *pMsg) {(void)pMsg;}
+void ctcptime(MsgItem_t *pMsg) {(void)pMsg;}
+
+void logoff(MsgItem_t *pMsg) {(void)pMsg;}
+void greeting(MsgItem_t *pMsg) {(void)pMsg;}
+void help(MsgItem_t *pMsg) {(void)pMsg;}
+void version(MsgItem_t *pMsg) {(void)pMsg;}
+void hello(MsgItem_t *pMsg) {(void)pMsg;}
+void ident(MsgItem_t *pMsg) {(void)pMsg;}
+void password(MsgItem_t *pMsg) {(void)pMsg;}
+void inviteuser(MsgItem_t *pMsg) {(void)pMsg;}
+void chanmode(MsgItem_t *pMsg) {(void)pMsg;}
+void accountlist(MsgItem_t *pMsg) {(void)pMsg;}
+void accountmode(MsgItem_t *pMsg) {(void)pMsg;}
+void say(MsgItem_t *pMsg) {(void)pMsg;}
+void kickuser(MsgItem_t *pMsg) {(void)pMsg;}
+void setTopic(MsgItem_t *pMsg) {(void)pMsg;}
+void setGreeting(MsgItem_t *pMsg) {(void)pMsg;}
+void banuser(MsgItem_t *pMsg) {(void)pMsg;}
+void debanuser(MsgItem_t *pMsg) {(void)pMsg;}
+void restart(MsgItem_t *pMsg) {(void)pMsg;}
+void allsay(MsgItem_t *pMsg) {(void)pMsg;}
+void rmaccount(MsgItem_t *pMsg) {(void)pMsg;}
+void setNick(MsgItem_t *pMsg) {(void)pMsg;}
+void die(MsgItem_t *pMsg) {(void)pMsg;}
+void chanlist(MsgItem_t *pMsg) {(void)pMsg;}
+void rmChannel(MsgItem_t *pMsg) {(void)pMsg;}
+void addChannel(MsgItem_t *pMsg) {(void)pMsg;}
+void joinChannel(MsgItem_t *pMsg) {(void)pMsg;}
+void partChannel(MsgItem_t *pMsg) {(void)pMsg;}

--- a/testsuit/testsuit.c
+++ b/testsuit/testsuit.c
@@ -27,6 +27,7 @@
 #include "extract_test.h"
 #include "callbacklist_test.h"
 #include "configparser_test.h"
+#include "parser_pipeline_test.h"
 
 
 int main () {
@@ -106,6 +107,20 @@ int main () {
 
 	for (nIndex=0; nIndex<NUMBER_OF_CONFIGPARSER_TESTS; nIndex++ ) {
 		if (NULL == CU_add_test(pSuite, pstrConfigParserTestSet[nIndex].pDesc, pstrConfigParserTestSet[nIndex].TestFkt)){
+			CU_cleanup_registry();
+			return CU_get_error();
+		}
+	}
+
+	/* add a suite to the registry */
+	pSuite = CU_add_suite("ParserPipeline", init_parser_pipeline, clean_parser_pipeline);
+	if (NULL == pSuite) {
+		CU_cleanup_registry();
+		return CU_get_error();
+	}
+
+	for (nIndex=0; nIndex<NUMBER_OF_PARSER_PIPELINE_TESTS; nIndex++ ) {
+		if (NULL == CU_add_test(pSuite, pstrParserPipelineTestSet[nIndex].pDesc, pstrParserPipelineTestSet[nIndex].TestFkt)){
 			CU_cleanup_registry();
 			return CU_get_error();
 		}


### PR DESCRIPTION
### Motivation

- Add automated tests to cover the IRC message pre-parser pipeline (synchronous PING handling, bot commands, CTCP detection and ignoring unknown messages). 

### Description

- Introduce a new test header `testsuit/include/parser_pipeline_test.h` and test implementation `testsuit/parser_pipeline_test.c` implementing four `preParser` unit tests and test doubles to isolate parser dependencies. 
- Update `testsuit/Makefile.am` to include the new test source `parser_pipeline_test.c`, add `../src/parser.c` and `../src/cmdlist.c` to the test link list, and expose additional headers required by the tests. 
- Register the new test suite in `testsuit/testsuit.c` by including `parser_pipeline_test.h` and adding the `ParserPipeline` suite with its tests to the CUnit runner. 

### Testing

- Ran the test runner with `make check` / the CUnit basic runner (`testsuit`) against the updated test binary. All added `ParserPipeline` tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b1fff2c4832ea0f414af3fed6724)